### PR TITLE
Fix SSE endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # mcpdemo
+
+This project exposes a Spring AI MCP server. The SSE endpoint is available at `/mcp/message`.
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.ai.mcp.server.enabled=true
 spring.ai.mcp.server.name=LeaveManager
 spring.ai.mcp.server.version=1.0.0
 spring.ai.mcp.server.type=SYNC
-spring.ai.mcp.server.sse-message-endpoint=/mcp/messages
+spring.ai.mcp.server.sse-message-endpoint=/mcp/message
 
 # Server Configuration
 server.address=0.0.0.0


### PR DESCRIPTION
## Summary
- use default `/mcp/message` SSE endpoint
- document SSE endpoint in README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684eb70b1964832b99316a10a7a21fc9